### PR TITLE
call_EtherscanAPI.jl script fixes and documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# Etheroll
+# Etheroll statistical analysis
+
+See medium article:
+[Statistical analysis of Etheroll's random number generation](https://medium.com/@tucker.translator/statistical-analysis-of-etherolls-random-number-generation-ed06fdbdd2a4)
+
+This set of scripts is using the [Julia Programming Language](https://julialang.org/).
+
+## Install
+Install Julia lang (Ubuntu 18.04):
+```sh
+sudo snap install julia --classic
+```
+Insall package dependencies:
+```sh
+echo 'using Pkg; Pkg.add(["HTTP", "JSON"])' | julia
+```
+Run the scripts:
+```sh
+julia call_EtherscanAPI.jl
+```

--- a/call_EtherscanAPI.jl
+++ b/call_EtherscanAPI.jl
@@ -1,7 +1,13 @@
+using HTTP, JSON
+
+
+API_token = "" # to override with your Etherscan API key
 fb = 6290000 #first block to start from
 
 log_array = [] #for stroing event logs from API call
 for i in 1:400 #the logs come in batches of 1000 — get as many as possible
+    global fb
+    global API_token
     print(i,", ")
     link = "https://api.etherscan.io/api?module=logs&action=getLogs&fromBlock=$fb&toBlock=latest&address=0xa52e014b3f5cc48287c2d483a3e026c32cc76e6d&topic0=0x8dd0b145385d04711e29558ceab40b456976a2b9a7d648cc1bcd416161bf97b9&apikey=$API_token"
 
@@ -24,3 +30,4 @@ for i in 1:length(log_array)
     end
 end
 filter!(x->x !== 0, result_array) #results of 0 == failed tx
+print(result_array)


### PR DESCRIPTION
- renames the `call_EtherscanAPI.jl` using the jl extension
- adds missing package imports
- adds missing global keyword
- adds Ubuntu install instructions
- tested against `julia version 1.0.4`